### PR TITLE
Fix some name, class, race tags left in private db

### DIFF
--- a/wowvo_client/tts_utils.py
+++ b/wowvo_client/tts_utils.py
@@ -19,6 +19,9 @@ DATAMODULE_TABLE_GUARD_CLAUSE = 'if not VoiceOver or not VoiceOver.DataModules t
 REPLACE_DICT = {'$b': '\n', '$B': '\n', '$n': 'adventurer', '$N': 'Adventurer',
                 '$C': 'Adventurer', '$c': 'adventurer', '$R': 'Traveler', '$r': 'traveler', '$t citizen : citizen': 'citizen',
                 '$T Civvy : Civvy;': '',
+                '<name>': 'adventurer', '<Name>': 'Adventurer',
+                '<race>': 'traveler', '<Race>': 'Traveler',
+                '<class>': 'adventurer', '<Class>': 'Adventurer',
                  '—':',', '--':',', " - ":", ",
                  # Factions / Regions
                  "Draenei": "Dray-nai",


### PR DESCRIPTION
I've used provided acore DB and some quest had this <name> in cleanedText, so I've added these replaces